### PR TITLE
Set runtime for golang linting

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,0 +1,3 @@
+---
+run:
+  timeout: 10m


### PR DESCRIPTION
Hopefully makes linting fail with timeout less often.