### PR TITLE
Make sdafs work with the archive as currently offered

### DIFF
--- a/internal/sdafs/sdafs_test.go
+++ b/internal/sdafs/sdafs_test.go
@@ -155,34 +155,25 @@ func TestDatasetLoad(t *testing.T) {
 		httpmock.NewStringResponder(200, `[
 		{ "fileId": "1", 
 			"filePath":"/file1",
-			"fileSize": 14000,
-			"fileStatus": "ready",
-			"lastModified": "2023-12-08T15:12:13.06156Z",
-			"createdAt": "2023-12-08T15:12:13.06156Z"
+			"fileSize": 14000
 		}, 
 		{ "fileId": "2", 
 			"filePath":"/dir1/file2",
-			"fileSize": 1000,
-			"fileStatus": "ready",
-			"lastModified": "2023-12-08T15:12:13.06156Z",
-			"createdAt": "2023-12-08T15:12:13.06156Z"
+			"fileSize": 1000
 		},
 		{ "fileId": "3", 
 			"filePath":"/dir1/file3",
-			"fileSize": 1000,
-			"fileStatus": "pending",
-			"lastModified": "2023-12-08T15:12:13.06156Z",
-			"createdAt": "2023-12-08T15:12:13.06156Z"
+			"fileSize": 1000
 		}
 
 			]`))
 	err = sda.checkLoaded(sda.inodes[4])
 	assert.Nil(t, err, "Unexpected error")
-	assert.Equal(t, 6, len(sda.inodes), "inodes in sda is unexpected length")
+	assert.Equal(t, 7, len(sda.inodes), "inodes in sda is unexpected length")
 
 	// Repeat should just return directly with the same visible result
 	err = sda.checkLoaded(sda.inodes[4])
 	assert.Nil(t, err, "Unexpected error")
-	assert.Equal(t, 6, len(sda.inodes), "inodes in sda is unexpected length")
+	assert.Equal(t, 7, len(sda.inodes), "inodes in sda is unexpected length")
 
 }

--- a/internal/sdafs/sdafs_test.go
+++ b/internal/sdafs/sdafs_test.go
@@ -169,11 +169,11 @@ func TestDatasetLoad(t *testing.T) {
 			]`))
 	err = sda.checkLoaded(sda.inodes[4])
 	assert.Nil(t, err, "Unexpected error")
-	assert.Equal(t, 7, len(sda.inodes), "inodes in sda is unexpected length")
+	assert.Equal(t, 8, len(sda.inodes), "inodes in sda is unexpected length")
 
 	// Repeat should just return directly with the same visible result
 	err = sda.checkLoaded(sda.inodes[4])
 	assert.Nil(t, err, "Unexpected error")
-	assert.Equal(t, 7, len(sda.inodes), "inodes in sda is unexpected length")
+	assert.Equal(t, 8, len(sda.inodes), "inodes in sda is unexpected length")
 
 }


### PR DESCRIPTION
The archive has changed quite a bit in behaviour (filestatus metadata along with some other things are gone, there used to be a level in the filepath that had to be skipped that can no longer be).

This PR updates sdafs to deal with those things.